### PR TITLE
Replace 'var' visiblity keyword

### DIFF
--- a/code/CustomHtmlEditorConfig.php
+++ b/code/CustomHtmlEditorConfig.php
@@ -12,7 +12,7 @@ class CustomHTMLEditorConfig extends HTMLEditorConfig {
 	/**
 	 *	The identifier string
 	 */
-	var $configIdentifier;
+	public $configIdentifier;
 	
 	
 	/**


### PR DESCRIPTION
`var` keyword is deprecated but kept around for compatibility reasons.
http://www.php.net/manual/en/language.oop5.visibility.php
