### PR TITLE
Make Javascript requirement reference dynamic

### DIFF
--- a/code/CustomHTMLEditorLeftAndMainExtension.php
+++ b/code/CustomHTMLEditorLeftAndMainExtension.php
@@ -6,7 +6,7 @@ class CustomHTMLEditorLeftAndMainExtension extends Extension {
 	
 
 	function init() {
-		Requirements::javascript('customhtmleditorfield/javascript/CustomHTMLEditorField.js');
+		Requirements::javascript(basename(dirname(__DIR__)) . '/javascript/CustomHTMLEditorField.js');
 		CustomHTMLEditorLeftAndMainExtension::include_js();
 	}
 	


### PR DESCRIPTION
If you use the module with the name as cloned: silverstripe-customhtmleditorfield the JS wont get loaded since the path is hardcoded.
