### PR TITLE
Have setters return field, for invocation chaining

### DIFF
--- a/code/CustomHtmlEditorFieldExtension.php
+++ b/code/CustomHtmlEditorFieldExtension.php
@@ -11,6 +11,7 @@ class CustomHtmlEditorFieldExtension extends Extension
     public function setEditorConfig($identifier)
     {
         CustomHTMLEditorField::set_editor_config($this->owner, $identifier);
+        return $this->owner;
     }
 
     /**
@@ -43,6 +44,7 @@ class CustomHtmlEditorFieldExtension extends Extension
     public function setBodyClass($classes)
     {
         $this->owner->setAttribute('data-body-class', $classes);
+        return $this->owner;
     }
 
     /**


### PR DESCRIPTION
Allows for invocation chaining on field creation, eg your example could be written as:

```
$fields->addFieldToTab('Root.Footer', 
  HtmlEditorField::create('FooterText', 'Footer')
    ->setEditorConfig('footer')
    ->setBodyClass('footer-content');
);
```